### PR TITLE
Upgrade to beta apis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,10 @@ build.init: $(UP)
 # - To ensure the proper functioning of the end-to-end test resource pre-deletion hook, it is crucial to arrange your resources appropriately.
 #   You can check the basic implementation here: https://github.com/upbound/uptest/blob/main/internal/templates/01-delete.yaml.tmpl.
 # - UPTEST_DATASOURCE_PATH (optional), see https://github.com/upbound/uptest#injecting-dynamic-values-and-datasource
+SKIP_DELETE ?=
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e test/karpenter-xr.yaml,examples/network-xr.yaml,examples/eks-xr.yaml --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e test/karpenter-xr.yaml,examples/network-xr.yaml,examples/eks-xr.yaml --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 $(SKIP_DELETE) || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 
 # This target requires the following environment variables to be set:
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat ~/.aws/credentials)
+# Use `make e2e SKIP_DELETE=--skip-delete` to skip deletion of resources created during the test.
 e2e: build controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest
 
 render:

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -260,7 +260,7 @@ spec:
                                 "aws:RequestTag/kubernetes.io/cluster/%[2]s": "owned"
                               },
                               "StringLike": {
-                                "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                                "aws:RequestTag/karpenter.sh/nodepool": "*"
                               }
                             }
                           },
@@ -285,27 +285,26 @@ spec:
                                 ]
                               },
                               "StringLike": {
-                                "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                                "aws:RequestTag/karpenter.sh/nodepool": "*"
                               }
                             }
                           },
                           {
-                            "Sid": "AllowMachineMigrationTagging",
+                            "Sid": "AllowScopedResourceTagging",
                             "Effect": "Allow",
                             "Resource": "arn:aws:ec2:%[1]s:*:instance/*",
                             "Action": "ec2:CreateTags",
                             "Condition": {
                               "StringEquals": {
-                                "aws:ResourceTag/kubernetes.io/cluster/%[2]s": "owned",
-                                "aws:RequestTag/karpenter.sh/managed-by": "%[2]s"
+                                "aws:ResourceTag/kubernetes.io/cluster/%[2]s": "owned"
                               },
                               "StringLike": {
-                                "aws:RequestTag/karpenter.sh/provisioner-name": "*"
+                                "aws:ResourceTag/karpenter.sh/nodepool": "*"
                               },
                               "ForAllValues:StringEquals": {
                                 "aws:TagKeys": [
-                                  "karpenter.sh/provisioner-name",
-                                  "karpenter.sh/managed-by"
+                                  "karpenter.sh/nodeclaim",
+                                  "Name"
                                 ]
                               }
                             }
@@ -326,7 +325,7 @@ spec:
                                 "aws:ResourceTag/kubernetes.io/cluster/%[2]s": "owned"
                               },
                               "StringLike": {
-                                "aws:ResourceTag/karpenter.sh/provisioner-name": "*"
+                                "aws:ResourceTag/karpenter.sh/nodepool": "*"
                               }
                             }
                           },

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -786,12 +786,8 @@ spec:
                   chart:
                     name: karpenter
                     repository: oci://public.ecr.aws/karpenter
-                    version: v0.31.1
+                    version: v0.33.1
                   namespace: karpenter
-                  values:
-                    settings:
-                      aws:
-                        nodeNameConvention: ip-name
             patches:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
@@ -803,17 +799,12 @@ spec:
                 toFieldPath: spec.forProvider.values.serviceAccount.annotations[eks.amazonaws.com/role-arn]
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.clusterName
-                toFieldPath: spec.forProvider.values.settings.aws.clusterName
-              - type: FromCompositeFieldPath
-                fromFieldPath: status.karpenter.instanceProfileName
-                policy:
-                  fromFieldPath: Required
-                toFieldPath: spec.forProvider.values.settings.aws.defaultInstanceProfile
+                toFieldPath: spec.forProvider.values.settings.clusterName
               - type: FromCompositeFieldPath
                 fromFieldPath: status.karpenter.sqsQueueName
                 policy:
                   fromFieldPath: Required
-                toFieldPath: spec.forProvider.values.settings.aws.interruptionQueueName
+                toFieldPath: spec.forProvider.values.settings.interruptionQueueName
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
@@ -826,7 +817,7 @@ spec:
                           type: regexp
                     type: match
 
-          - name: karpenterProvisioner
+          - name: karpenterNodePool
             base:
               apiVersion: kubernetes.crossplane.io/v1alpha1
               kind: Object
@@ -834,58 +825,60 @@ spec:
                 deletionPolicy: Orphan
                 forProvider:
                   manifest:
-                    apiVersion: karpenter.sh/v1alpha5
-                    kind: Provisioner
+                    apiVersion: karpenter.sh/v1beta1
+                    kind: NodePool
                     metadata:
                       name: default
                     spec:
-                      consolidation:
-                        enabled: true
-                      kubeletConfiguration:
-                        containerRuntime: containerd
-                      labels:
-                        intent: apps
+                      disruption:
+                        consolidationPolicy: WhenUnderutilized
+                        expireAfter: 168h
+                      template:
+                        metadata:
+                          labels:
+                            intent: apps
+                        spec:
+                          nodeClassRef:
+                            apiVersion: karpenter.k8s.aws/v1beta1
+                            kind: EC2NodeClass
+                            name: default
+                          requirements:
+                            - key: karpenter.k8s.aws/instance-category
+                              operator: In
+                              values:
+                                - c
+                                - m
+                                - r
+                                - i
+                                - d
+                            - key: karpenter.k8s.aws/instance-cpu
+                              operator: In
+                              values:
+                                - "4"
+                                - "8"
+                                - "16"
+                                - "32"
+                                - "48"
+                                - "64"
+                            - key: karpenter.sh/capacity-type
+                              operator: In
+                              values:
+                                - spot
+                                - on-demand
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - arm64
                       limits:
-                        resources:
-                          cpu: 1000
-                          memory: 500Gi
-                      providerRef:
-                        name: default
-                      requirements:
-                        - key: karpenter.k8s.aws/instance-category
-                          operator: In
-                          values:
-                            - c
-                            - m
-                            - r
-                            - i
-                            - d
-                        - key: karpenter.k8s.aws/instance-cpu
-                          operator: In
-                          values:
-                            - "4"
-                            - "8"
-                            - "16"
-                            - "32"
-                            - "48"
-                            - "64"
-                        - key: karpenter.sh/capacity-type
-                          operator: In
-                          values:
-                            - spot
-                            - on-demand
-                        - key: kubernetes.io/arch
-                          operator: In
-                          values:
-                            - amd64
-                            - arm64
-                      ttlSecondsUntilExpired: 604800
+                        cpu: 1000
+                        memory: 500Gi
             patches:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
                 toFieldPath: spec.providerConfigRef.name
 
-          - name: karpenterAWSNodeTemplate
+          - name: karpenterNodeClass
             base:
               apiVersion: kubernetes.crossplane.io/v1alpha1
               kind: Object
@@ -893,13 +886,14 @@ spec:
                 deletionPolicy: Orphan
                 forProvider:
                   manifest:
-                    apiVersion: karpenter.k8s.aws/v1alpha1
-                    kind: AWSNodeTemplate
+                    apiVersion: karpenter.k8s.aws/v1beta1
+                    kind: EC2NodeClass
                     metadata:
                       name: default
                     spec:
+                      amiFamily: AL2 # Amazon Linux 2
                       tags:
-                        KarpenterProvisionerName: default
+                        KarpenterNodePoolName: default
                         NodeType: default
                         intent: apps
             patches:
@@ -908,10 +902,10 @@ spec:
                 toFieldPath: spec.providerConfigRef.name
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
-                toFieldPath: spec.forProvider.manifest.spec.subnetSelector[networks.aws.platform.upbound.io/network-id]
+                toFieldPath: spec.forProvider.manifest.spec.subnetSelectorTerms[0].tags[networks.aws.platform.upbound.io/network-id] #(TODO: ytsarev) check tags
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
-                toFieldPath: spec.forProvider.manifest.spec.securityGroupSelector[eks.aws.platform.upbound.io/discovery]
+                toFieldPath: spec.forProvider.manifest.spec.securityGroupSelectorTerms[0].tags[eks.aws.platform.upbound.io/discovery]
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
                 toFieldPath: spec.forProvider.manifest.spec.tags[karpenter.sh/discovery]

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -5,6 +5,7 @@ echo "Running setup.sh"
 echo "Waiting until all configurations are healthy/installed..."
 "${KUBECTL}" wait configuration.pkg --all --for=condition=Healthy --timeout 5m
 "${KUBECTL}" wait configuration.pkg --all --for=condition=Installed --timeout 5m
+"${KUBECTL}" wait configurationrevisions.pkg --all --for=condition=Healthy --timeout 5m
 
 echo "Creating cloud credential secret..."
 "${KUBECTL}" -n upbound-system create secret generic aws-creds --from-literal=credentials="${UPTEST_CLOUD_CREDENTIALS}" \
@@ -50,7 +51,7 @@ get_annotation() {
 while true; do
     resource_info=$(kubectl get cluster.eks.aws.upbound.io -o json)
     annotation_value=$(get_annotation "$resource_info" "crossplane.io/external-name")
-    
+
     if [ -n "$annotation_value" ]; then
         cat <<EOF | "${KUBECTL}" apply -f -
 apiVersion: aws.platform.upbound.io/v1alpha1
@@ -65,6 +66,6 @@ spec:
 EOF
         exit 0
     fi
-    
+
     sleep 1
 done


### PR DESCRIPTION
### Description of your changes

Migrate to beta karpenter APIs

* Migrate to latest version and beta APIs
* make configuration installation more reliable
* Update policy to comply with new karpenter version
* Add `make e2e SKIP_DELETE=--skip-delete` ability to Makefile for debugging setup


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k apply -f test/workload.yaml
k get nodeclaims.karpenter.sh
NAME            TYPE         ZONE         NODE                                            READY   AGE
default-6dvqb   c6g.xlarge   us-west-2b   ip-192-168-117-198.us-west-2.compute.internal   True    26m
 k get pod
NAME                        READY   STATUS    RESTARTS   AGE
workload-7bf7b77746-f4qjs   1/1     Running   0          41m
workload-7bf7b77746-g228r   1/1     Running   0          41m
workload-7bf7b77746-k9ckp   1/1     Running   0          41m
workload-7bf7b77746-n8zv6   1/1     Running   0          41m
workload-7bf7b77746-ss8c5   1/1     Running   0          41m
```
