### PR TITLE
Modify "Eventbridge Rule" resource patches to include spec.prameters.id as prefix

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -505,28 +505,22 @@ spec:
                 patchSetName: deletionPolicy
               - type: PatchSet
                 patchSetName: region
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-healthevent'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: healthevent
-                          type: regexp
-                    type: match
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+                type: CombineFromComposite
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-healthevent'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.name
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: healthevent
-                          type: regexp
-                    type: match
+                type: CombineFromComposite
 
           - name: ruleSpotInterrupt
             base:
@@ -554,28 +548,23 @@ spec:
                 patchSetName: deletionPolicy
               - type: PatchSet
                 patchSetName: region
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-spotinterrupt'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: spotinterrupt
-                          type: regexp
-                    type: match
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+                type: CombineFromComposite
+
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-spotinterrupt'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.name
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: spotinterrupt
-                          type: regexp
-                    type: match
+                type: CombineFromComposite
 
           - name: ruleInstanceRebalance
             base:
@@ -603,28 +592,22 @@ spec:
                 patchSetName: deletionPolicy
               - type: PatchSet
                 patchSetName: region
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-instancerebalance'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: instancerebalance
-                          type: regexp
-                    type: match
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+                type: CombineFromComposite
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-instancerebalance'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.name
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: instancerebalance
-                          type: regexp
-                    type: match
+                type: CombineFromComposite
 
           - name: ruleInstanceStateChange
             base:
@@ -652,28 +635,22 @@ spec:
                 patchSetName: deletionPolicy
               - type: PatchSet
                 patchSetName: region
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-instancestatechange'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: instancestatechange
-                          type: regexp
-                    type: match
-              - type: FromCompositeFieldPath
-                fromFieldPath: spec.parameters.id
+                type: CombineFromComposite
+              - combine:
+                  strategy: string
+                  string:
+                    fmt: '%s-instancestatechange'
+                  variables:
+                    - fromFieldPath: spec.parameters.id
                 toFieldPath: metadata.name
-                transforms:
-                  - match:
-                      fallbackValue: null
-                      patterns:
-                        - regexp: .*
-                          result: instancestatechange
-                          type: regexp
-                    type: match
+                type: CombineFromComposite
 
           - name: ruleHealthEventTarget
             base:


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
This PR changes the patch content for all Rule resources to include spec.prameters.id as name prefix. Without this change, rule resources are created with names that conflict when a second Karpenter instance is provisioned on the same AWS account. 
-->

Fixes #485-676

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [] Run `make reviewable` to ensure this PR is ready for review.
- [] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
I have tested this change by provisioning 2 different EKS clusters and provisioned 2 Karpenter instances on the same AWS account and observed that Amazon Eventbridge rule resources were created with unique names to include the id as prefix. 
-->
